### PR TITLE
Using /bin/echo

### DIFF
--- a/scripts/_flatten-file.sh
+++ b/scripts/_flatten-file.sh
@@ -2,6 +2,6 @@
 
 # Helper script to flatten license file into one line.
 while read line ; do
-	echo -n $line
+	/bin/echo -n $line
 done < "$1"
 echo


### PR DESCRIPTION
At least on my Mac, only `/bin/echo` understands `-n`. With just `echo`, I get a literal `-n` in the properties file and an error reading the license.
