### PR TITLE
Path-style addressing requires region

### DIFF
--- a/config/cfn-template.json
+++ b/config/cfn-template.json
@@ -525,7 +525,7 @@
                         },
                         "files" : {
                             "/var/lib/tomcat7/webapps/ROOT.war" : {
-                                "source" : { "Fn::Join" : [ "", [ "https://s3.amazonaws.com/", { "Ref" : "SrcBucket" }, "/", { "Ref" : "WarFile" } ] ]},
+                                "source" : { "Fn::Join" : [ "", [ "https://s3-", { "Ref" : "AWS::Region" }, ".amazonaws.com/", { "Ref" : "SrcBucket" }, "/", { "Ref" : "WarFile" } ] ]},
                                 "mode" : "000644",
                                 "owner" : "tomcat",
                                 "group" : "tomcat"

--- a/config/cfn-template.json
+++ b/config/cfn-template.json
@@ -357,13 +357,13 @@
                     "config" : {
                         "files" : {
                             "/tmp/jdk.rpm" : {
-                                "source" : { "Fn::Join" : [ "", [ "https://s3.amazonaws.com/", { "Ref" : "SrcBucket" }, "/", { "Ref" : "JdkRpm" } ] ]},
+                                "source" : { "Fn::Join" : [ "", [ "https://s3-", { "Ref" : "AWS::Region" }, ".amazonaws.com/", { "Ref" : "SrcBucket" }, "/", { "Ref" : "JdkRpm" } ] ]},
                                 "mode" : "000644",
                                 "owner" : "root",
                                 "group" : "root"
                             },
                             "/tmp/datomic-license-key" : {
-                                "source" : { "Fn::Join" : [ "", [ "https://s3.amazonaws.com/", { "Ref" : "SrcBucket" }, "/", { "Ref" : "LicenseFile" } ] ]},
+                                "source" : { "Fn::Join" : [ "", [ "https://s3-", { "Ref" : "AWS::Region" }, ".amazonaws.com/", { "Ref" : "SrcBucket" }, "/", { "Ref" : "LicenseFile" } ] ]},
                                 "mode" : "000600",
                                 "owner" : "root",
                                 "group" : "root"


### PR DESCRIPTION
Using `https://s3.amazonaws.com/mybucket/puppy.jpg` only works for US Standard region, as is [described here](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html). In other regions, the retrieve of the war from S3 gets a redirect and `/var/lib/tomcat7/webapps/ROOT.war` ends up containing only this error message:

```
<Error>
  <Code>PermanentRedirect</Code>
  <Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message>
  ...
```

The correct URI for the `eu-west-1` region is `https://s3-eu-west-1.amazonaws.com/mybucket/puppy.jpg`.
