### PR TITLE
Invalid Datomic URI without database name

### DIFF
--- a/config/cfn-template.json
+++ b/config/cfn-template.json
@@ -546,7 +546,7 @@
                                                { "Fn::FindInMap" : [ "stage", { "Ref" : "Stage" }, "peerInstanceType" ] },
                                                "MaxPermSize" ] }, 
                                     " -DDATOMIC_URI=datomic:ddb://", { "Ref" : "AWS::Region" },
-                                      "/", { "Fn::FindInMap" : [ "stage", { "Ref" : "Stage" }, "ddbTable" ] }, "/",
+                                      "/", { "Fn::FindInMap" : [ "stage", { "Ref" : "Stage" }, "ddbTable" ] }, "/clj-west",
                                     "\"\n"
                                 ] ]}
                             }


### PR DESCRIPTION
For some reason there is no database name in the `DATOMIC_URI` in the template. This results in a failure to deploy the web application. The error can be seen in `/var/log/tomcat7/localhost.<date>.log`:

```
java.lang.IllegalArgumentException: :db.error/invalid-db-uri Invalid database URI datomic:ddb://eu-west-1/datomic_demo_staging/
```
