### PR TITLE
Now handling BSD stat as well

### DIFF
--- a/scripts/create-stack.sh
+++ b/scripts/create-stack.sh
@@ -5,11 +5,19 @@ if [ -z "$1" -o -z "$2" ]; then
 	exit 1
 fi
 
-set -e
 . `dirname $0`/.demo.env
 
-warfile=uberwars/`basename $1 .war`-`stat -c %Y $1`.war
-# Uploaded war file will have modifcation ts embedded in its name
+# BSD stat has other flags
+stat="stat -c %Y"
+stat -c %Y $file > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+        stat="stat -f %m"
+fi
+
+set -e
+
+warfile=uberwars/`basename $1 .war`-$($stat $1).war
+# Uploaded war file will have modification ts embedded in its name
 aws s3 cp "$1" "s3://$SRCBUCKET/$warfile"
 
 parameters="--parameters ParameterKey=SrcBucket,ParameterValue=$SRCBUCKET"

--- a/scripts/update-stack.sh
+++ b/scripts/update-stack.sh
@@ -5,10 +5,18 @@ if [ -z "$1" -o -z "$2" ]; then
 	exit 1
 fi
 
-set -e
 . `dirname $0`/.demo.env
 
-warfile=uberwars/`basename $1 .war`-`stat -c %Y $1`.war
+# BSD stat has other flags
+stat="stat -c %Y"
+stat -c %Y $file > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+        stat="stat -f %m"
+fi
+
+set -e
+
+warfile=uberwars/`basename $1 .war`-$($stat $1).war
 # Uploaded war file will have modifcation ts embedded in its name
 aws s3 cp "$1" "s3://$SRCBUCKET/$warfile"
 


### PR DESCRIPTION
BSD stat (default on Macs) has a different flag for timestamp: `-f %m` instead of `-c %Y`.
The command may fail when determining which one to use, so I moved the `set -e`.
